### PR TITLE
Refactoring

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Stephen Callear
+Copyright (c) 2018 Stephen Callear
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Both the proxy integration event and lambda context are stored in the request co
 ```
 func main() {
     h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        e := chop.GetEvent(r)
+        e, _ := chop.GetEvent(r)
         fmt.Fprintf(w, "Stage: %s", e.RequestContext.Stage)
         
-        c := chop.GetContext(r)
+        c, _ := chop.GetContext(r)
         fmt.Fprintf(w, "AwsRequestID: %s", c.AwsRequestID)
     })
     chop.Start(h)


### PR DESCRIPTION
* Update `GetEvent` and `GetContext` to return a `bool` indicating that the value exists in the request context with supporting tests
* Assign the supplied `context.Context` to the request as previously it was simply using `context.Background`
* Simplify `GetContext` based on the above change
* Update readme to reflect contract changes
* Update license date
